### PR TITLE
Changes for standard hardware profile

### DIFF
--- a/lib/qubinode_ansible.sh
+++ b/lib/qubinode_ansible.sh
@@ -28,7 +28,7 @@ function ensure_supported_ansible_version () {
     if [ "A${ANSIBLE_VERSION_GOOD}" == "AYES" ]
     then
         printf "%s\n" ""
-        printf "%s\n" " %{cyn}**WARNING**${end}"
+        printf "%s\n" " ${cyn}**WARNING**${end}"
         printf "%s\n" " Your ansible version $CURRENT_ANSIBLE_VERSION is later than the tested version of $ANSIBLE_VERSION"
     fi
 }

--- a/lib/qubinode_hardware_check.sh
+++ b/lib/qubinode_hardware_check.sh
@@ -78,10 +78,22 @@ function check_memory_size () {
 
 function check_hardware_resources () {
     check_disk_size
-    sed -i "s/storage_profile:.*/storage_profile: "$STORAGE_PROFILE"/g" "${vars_file}"
-
     check_memory_size
-    sed -i "s/memory_profile:.*/memory_profile: "$MEMORY_PROFILE"/g" "${vars_file}"
+
+    if [[ "$STORAGE_PROFILE" != "$MEMORY_PROFILE" ]] && [[ "$STORAGE_PROFILE" != minimal ]] && [[ "$MEMORY_PROFILE" != minimal ]]
+    then
+        local PROFILE=standard
+        sed -i "s/storage_profile:.*/storage_profile: "$PROFILE"/g" "${vars_file}"
+        sed -i "s/memory_profile:.*/memory_profile: "$PROFILE"/g" "${vars_file}"
+    elif [[ "$STORAGE_PROFILE" != "$MEMORY_PROFILE" ]] && [[ "$STORAGE_PROFILE" == minimal ]] || [[ "$MEMORY_PROFILE" == minimal ]]
+    then
+        local PROFILE=minimal
+        sed -i "s/storage_profile:.*/storage_profile: "$PROFILE"/g" "${vars_file}"
+        sed -i "s/memory_profile:.*/memory_profile: "$PROFILE"/g" "${vars_file}"
+    else
+        sed -i "s/storage_profile:.*/storage_profile: "$STORAGE_PROFILE"/g" "${vars_file}"
+        sed -i "s/memory_profile:.*/memory_profile: "$MEMORY_PROFILE"/g" "${vars_file}"
+    fi
 }
 
 function select_openshift3_cluster_size () {

--- a/lib/qubinode_userinput.sh
+++ b/lib/qubinode_userinput.sh
@@ -59,6 +59,8 @@ function ask_for_vault_values () {
 }
 
 function ask_user_input () {
+    idm_server_ip=$(awk '/idm_server_ip:/ {print $2;exit}' "${idm_vars_file}" |tr -d '"')
+    idm_check_static_ip=$(awk '/idm_check_static_ip:/ {print $2;exit}' "${idm_vars_file}" |tr -d '"')
     if [ "A${teardown}" != "Atrue" ]
     then 
         printf "\n\n${yel}    ***************************${end}\n"

--- a/samples/idm.yml
+++ b/samples/idm.yml
@@ -5,6 +5,7 @@
 # The qubinode-installer depends on IdM as the DNS server.
 # If there is an existing Idm, then set this to no.
 deploy_idm_server: yes
+ask_use_existing_idm: yes
 
 # IDM server attributes
 idm_server_ip: ""


### PR DESCRIPTION
- if storage or memory only meets the minimum requirement then deploy a minimal size ocp3 cluster
- if storage or memory size does not match and either does not match minimal, deploy a standard ocp3 cluster
- ensure the only ask about custom IdM once