### PR TITLE
BUG: fix multiple issues while testing on RHEL8

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -14,7 +14,7 @@ stdout_callback = yaml
 # Use the stdout_callback when running ad-hoc commands.
 bin_ansible_callbacks = True
 
-vault_password_file  = ~/.vaultkey
+vault_password_file  = {{ ansible_env.HOME }}/.vaultkey
 library              = playbooks/modules
 #allow_unsafe_lookups = False
 jinja2_native = False

--- a/docs/qubinode/troubleshooting-monitoring.md
+++ b/docs/qubinode/troubleshooting-monitoring.md
@@ -8,19 +8,19 @@ While OpenShift is deploying you can open a new terminal sshh into your box and 
 When Bootstrap is starting 
 ```
 # OpenShift 
-tail -f /home/${USER}/qubinode-installer/ocp4/bootstrap-complete.log
+tail -f ${HOME}/qubinode-installer/ocp4/bootstrap-complete.log
 
 # OKD 
-tail -f /home/${USER}/qubinode-installer/okd/bootstrap-complete.log
+tail -f ${HOME}/qubinode-installer/okd/bootstrap-complete.log
 ```
 
 Waiting for Installation to Complete
 ```
 # OpenShift 
-tail -f /home/${USER}/qubinode-installer/ocp4/.openshift_install.log
+tail -f ${HOME}/qubinode-installer/ocp4/.openshift_install.log
 
 # OKD 
-tail -f /home/${USER}/qubinode-installer/okd4/.openshift_install.log
+tail -f ${HOME}/qubinode-installer/okd4/.openshift_install.log
 ```
 
 **To exit out of tail hit CTRL+C**

--- a/lib/configure_ansible_runner.sh
+++ b/lib/configure_ansible_runner.sh
@@ -53,9 +53,9 @@ EOF
 function configure_ansible_runner_systemd(){
     if [ ! -f /usr/share/ansible-runner-service ];
     then
-      mkdir -p /home/"${USER}"/qubinode-installer/env
-      ln -s /home/"${USER}"/qubinode-installer/playbooks  /home/"${USER}"/qubinode-installer/project 
-      sudo ln -s  /home/"${USER}"/qubinode-installer/playbooks /etc/ansible-runner-service/project
+      mkdir -p ${HOME}/qubinode-installer/env
+      ln -s ${HOME}/qubinode-installer/playbooks  ${HOME}/qubinode-installer/project 
+      sudo ln -s  ${HOME}/qubinode-installer/playbooks /etc/ansible-runner-service/project
       if [ ! -f /etc/ansible-runner-service/config.yaml ]
       then 
         ansible_runner_config_yaml
@@ -69,8 +69,8 @@ function configure_ansible_runner_systemd(){
 
 # Change valut key path in ansible.cfg file
 function update_ansible_cfg(){
-    if [ -f /home/"${USER}"/qubinode-installer/ansible.cfg ];
+    if [ -f ${HOME}/qubinode-installer/ansible.cfg ];
     then 
-      sed -i 's/vault_password_file  = ~\/.vaultkey/vault_password_file  = \/home\/'"${USER}"'\/.vaultkey/g'  /home/"${USER}"/qubinode-installer/ansible.cfg
+      sed -i 's/vault_password_file  = ~\/.vaultkey/vault_password_file  = \/home\/'"${USER}"'\/.vaultkey/g'  ${HOME}/qubinode-installer/ansible.cfg
     fi 
 }

--- a/lib/configure_ansible_runner.sh
+++ b/lib/configure_ansible_runner.sh
@@ -27,7 +27,7 @@ version: 1
 # playbooks_root_dir
 # location of the playbooks that the service will start
 # playbooks_root_dir: './samples'
-playbooks_root_dir: '/home/${USER}/qubinode-installer/'
+playbooks_root_dir: '${HOME}/qubinode-installer/'
 
 # port
 # tcp port for the service to listen to

--- a/lib/configure_ansible_runner.sh
+++ b/lib/configure_ansible_runner.sh
@@ -71,6 +71,6 @@ function configure_ansible_runner_systemd(){
 function update_ansible_cfg(){
     if [ -f ${HOME}/qubinode-installer/ansible.cfg ];
     then 
-      sed -i 's/vault_password_file  = ~\/.vaultkey/vault_password_file  = \/home\/'"${USER}"'\/.vaultkey/g'  ${HOME}/qubinode-installer/ansible.cfg
+      sed -i 's/vault_password_file  = ~\/.vaultkey/vault_password_file  = '"${HOME}"'\/.vaultkey/g'  ${HOME}/qubinode-installer/ansible.cfg
     fi 
 }

--- a/lib/configure_ansible_runner.sh
+++ b/lib/configure_ansible_runner.sh
@@ -66,11 +66,3 @@ function configure_ansible_runner_systemd(){
       #sudo systemctl status ansible-runner-service.service
     fi
 }
-
-# Change valut key path in ansible.cfg file
-function update_ansible_cfg(){
-    if [ -f ${HOME}/qubinode-installer/ansible.cfg ];
-    then 
-      sed -i 's/vault_password_file  = ~\/.vaultkey/vault_password_file  = '"${HOME}"'\/.vaultkey/g'  ${HOME}/qubinode-installer/ansible.cfg
-    fi 
-}

--- a/lib/get_qubinode.sh
+++ b/lib/get_qubinode.sh
@@ -53,7 +53,7 @@ function wget_download(){
 
 # start the qubinode installer check and download if does not exist
 function start_qubinode_download(){
-  if  [ ! -d /home/${USER}/qubinode-installer ];
+  if  [ ! -d ${HOME}/qubinode-installer ];
   then 
     if [ ! -x /usr/bin/unzip ] ; then
       echo "unzip found on system."

--- a/lib/get_qubinode.sh
+++ b/lib/get_qubinode.sh
@@ -80,9 +80,9 @@ function start_qubinode_download(){
 
 # Remove qubinode installer and conpoments
 function remove_qubinode_folder(){
-    if [ -d  /home/"${USER}"/qubinode-installer ];
+    if [ -d  ${HOME}/qubinode-installer ];
     then 
-        sudo rm -rf /home/"${USER}"/qubinode-installer
+        sudo rm -rf ${HOME}/qubinode-installer
     fi 
 
     if [ -d /usr/share/ansible-runner-service ] && [ ! -f /etc/systemd/system/ansible-runner-service.service ];
@@ -92,10 +92,10 @@ function remove_qubinode_folder(){
       sudo rm -rf /tmp/ansible-runner-service/
     fi 
 
-    if [ -f /home/"${USER}"/.ssh/id_rsa ];
+    if [ -f ${HOME}/.ssh/id_rsa ];
     then
-      sudo rm -rf /home/"${USER}"/.ssh/id_rsa 
-      sudo rm -rf /home/"${USER}"/.ssh/id_rsa.pub
+      sudo rm -rf ${HOME}/.ssh/id_rsa 
+      sudo rm -rf ${HOME}/.ssh/id_rsa.pub
     fi  
 
 }

--- a/lib/qubinode_rpm_packages.sh
+++ b/lib/qubinode_rpm_packages.sh
@@ -46,8 +46,8 @@ function install_requirements(){
 }
 
 function configure_vault_key(){
-    if [ ! -f /home/${USER}/.vaultkey ];
+    if [ ! -f ${HOME}/.vaultkey ];
     then
-      openssl rand -base64 512|xargs > "/home/${USER}/.vaultkey"
+      openssl rand -base64 512|xargs > "${HOME}/.vaultkey"
     fi
 }

--- a/lib/qubinode_rpm_packages.sh
+++ b/lib/qubinode_rpm_packages.sh
@@ -1,7 +1,7 @@
 function configure_rhel8_packages(){
     sudo dnf clean all > /dev/null 2>&1
     sudo dnf install -y -q -e 0  python3-pip ansible git vim  python3-devel gcc
-    sudo dnf  install -y -q -e 0 container-tools -y
+    sudo dnf module install -y -q -e 0 container-tools
 }
 
 function configure_centos8_packages(){

--- a/lib/qubinode_utils.sh
+++ b/lib/qubinode_utils.sh
@@ -8,7 +8,7 @@ function generate_sshkey(){
 # setting ansible config enviornment for ansible runner 
 function set_ansible_config_env(){
     export ANSIBLE_CONFIG="${HOME}/qubinode-installer/ansible.cfg"
-    echo 'export ANSIBLE_CONFIG="/home/'"${USER}"'/qubinode-installer/ansible.cfg"' >> ${HOME}/.bashrc
+    echo 'export ANSIBLE_CONFIG="'"${HOME}"'/qubinode-installer/ansible.cfg"' >> ${HOME}/.bashrc
 }
 
 

--- a/lib/qubinode_utils.sh
+++ b/lib/qubinode_utils.sh
@@ -8,7 +8,7 @@ function generate_sshkey(){
 # setting ansible config enviornment for ansible runner 
 function set_ansible_config_env(){
     export ANSIBLE_CONFIG="${HOME}/qubinode-installer/ansible.cfg"
-    echo 'export ANSIBLE_CONFIG="/home/'"${USER}"'/qubinode-installer/ansible.cfg"' >> /home/"${USER}"/.bashrc
+    echo 'export ANSIBLE_CONFIG="/home/'"${USER}"'/qubinode-installer/ansible.cfg"' >> ${HOME}/.bashrc
 }
 
 

--- a/lib/qubinode_utils.sh
+++ b/lib/qubinode_utils.sh
@@ -2,12 +2,12 @@
 #set -xe 
 
 function generate_sshkey(){
-   ssh-keygen -f "/home/${USER}/.ssh/id_rsa" -q -N '' 
+   ssh-keygen -f "${HOME}/.ssh/id_rsa" -q -N '' 
 }
 
 # setting ansible config enviornment for ansible runner 
 function set_ansible_config_env(){
-    export ANSIBLE_CONFIG="/home/${USER}/qubinode-installer/ansible.cfg"
+    export ANSIBLE_CONFIG="${HOME}/qubinode-installer/ansible.cfg"
     echo 'export ANSIBLE_CONFIG="/home/'"${USER}"'/qubinode-installer/ansible.cfg"' >> /home/"${USER}"/.bashrc
 }
 

--- a/playbooks/openshift_ldap.yml
+++ b/playbooks/openshift_ldap.yml
@@ -10,9 +10,8 @@
     - vars/ocp4.yml
   vars:
     dn_attribute: []
-    homedir: "{{ lookup('env','HOME') }}"
     bind_user_pass: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"
-    vault_pass_file: "{{ homedir }}/.vaultkey"
+    vault_pass_file: "{{ ansible_env.HOME }}/.vaultkey"
     vault_file: "{{ project_dir }}/playbooks/vars/vault.yml"
 
   environment:

--- a/qubinode-installerv2.sh
+++ b/qubinode-installerv2.sh
@@ -41,7 +41,6 @@ function main(){
             install_requirements
             configure_vault_key
             install_ansible_runner_service
-            update_ansible_cfg
             generate_sshkey
             set_ansible_config_env
             configure_ansible_runner_systemd
@@ -57,7 +56,6 @@ function main(){
             install_requirements
             configure_vault_key
             install_ansible_runner_service
-            update_ansible_cfg
             generate_sshkey
             set_ansible_config_env
             configure_ansible_runner_systemd

--- a/qubinode-installerv2.sh
+++ b/qubinode-installerv2.sh
@@ -37,7 +37,7 @@ function main(){
             printf "%s\n" "${grn} $(cat /etc/redhat-release) detected. Configuring system for qubinode installer${end}"
             check_rhsm_status
             configure_rhel8_subscriptions
-            configure_rhel8_packagesv
+            configure_rhel8_packages
             install_requirements
             configure_vault_key
             install_ansible_runner_service

--- a/samples/all.yml
+++ b/samples/all.yml
@@ -44,7 +44,7 @@ preappend_host_name: "{{ instance_prefix }}-{{ product }}-"
 # This should be moved
 cluster_name: qbn
 
-vm_public_key: "/home/{{ admin_user }}/.ssh/id_rsa.pub"
+vm_public_key: "{{ ansible_env.USER }}/.ssh/id_rsa.pub"
 update_inventory: true
 vm_data_dir: "/var/lib/vmdata"
 inventory_file: "{{ inventory_dir }}/hosts"

--- a/samples/ocp4.yml
+++ b/samples/ocp4.yml
@@ -15,7 +15,7 @@ ocp4_image: 4.5.6
 
 # User info
 local_user_account: "{{ admin_user }}"
-local_user_ssh_public_key: "/home/{{ local_user_account }}/.ssh/id_rsa.pub"
+local_user_ssh_public_key: "{{ ansible_env.HOME }}/.ssh/id_rsa.pub"
 ssh_ocp4_public_key: "{{ lookup('file', local_user_ssh_public_key) }}"
 
 ########################

--- a/samples/okd4.yml
+++ b/samples/okd4.yml
@@ -27,7 +27,7 @@ family_tree: "Fedora CoreOS"
 
 # User info
 local_user_account: "{{ admin_user }}"
-local_user_ssh_public_key: "/home/{{ local_user_account }}/.ssh/id_rsa.pub"
+local_user_ssh_public_key: "{{ ansible_env.HOME }}/.ssh/id_rsa.pub"
 ssh_ocp4_public_key: "{{ lookup('file', local_user_ssh_public_key) }}"
 
 ########################

--- a/samples/okd4_baremetal.yml
+++ b/samples/okd4_baremetal.yml
@@ -22,7 +22,7 @@ family_tree: "Fedora CoreOS"
 
 # User info
 local_user_account: "{{ admin_user }}"
-local_user_ssh_public_key: "/home/{{ local_user_account }}/.ssh/id_rsa.pub"
+local_user_ssh_public_key: "{{ ansible_env.HOME }}/.ssh/id_rsa.pub"
 ssh_ocp4_public_key: "{{ lookup('file', local_user_ssh_public_key) }}"
 
 ########################


### PR DESCRIPTION
Validated on RHEL8 Libvirt VM

Resolves extra trailing character in function name error:
```
./qubinode-installerv2.sh: line 40: configure_rhel8_packagesv: command not found
```
Resolves pkg install cmd syntax error:
```
Error: Unable to find a match: container-tools
```
Resolves path variable error when running as root:
```
./lib/qubinode_rpm_packages.sh: line 51: /home/root/.vaultkey: No such file or directory
140508021139264:error:02012020:system library:fflush:Broken pipe:crypto/bio/bss_file.c:319:fflush()
140508021139264:error:20074002:BIO routines:file_ctrl:system lib:crypto/bio/bss_file.c:321:
```
Continue resolving other home path errors when running as root including:
```
Saving key "/home/root/.ssh/id_rsa" failed: No such file or directory
```